### PR TITLE
Fix bot script run directly

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -27,7 +27,7 @@ def test_openai_bot_sequential(monkeypatch):
     def fake_create(**kwargs):
         return responses.pop(0)
 
-    monkeypatch.setattr("bot.bot.openai.ChatCompletion.create", fake_create)
+    monkeypatch.setattr("bot.bot._create_chat_completion", fake_create)
     bot_instance = OpenAIBot()
     reply = bot_instance.ask("hello")
     assert reply == "second"


### PR DESCRIPTION
## Summary
- ensure the bot package root is on `sys.path` when running `bot.py` directly
- add compatibility wrapper for OpenAI v1
- create client when available to match new docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863cb728af083208820ff37a1ecfb80