### PR TITLE
Enable image uploads with GPT-4o

### DIFF
--- a/bot/settings.py
+++ b/bot/settings.py
@@ -2,7 +2,7 @@
 
 TELEGRAM_TOKEN = "YOUR_TELEGRAM_TOKEN"
 OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
-MODEL = "gpt-3.5-turbo"
+MODEL = "gpt-4o"
 CONTEXT_SIZE = 4096
 
 # List of assistants interacting with each other.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -31,3 +31,19 @@ def test_openai_bot_sequential(monkeypatch):
     bot_instance = OpenAIBot()
     reply = bot_instance.ask("hello")
     assert reply == "second"
+
+
+def test_openai_bot_image(monkeypatch):
+    content = [
+        {"type": "text", "text": "hi"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+
+    def fake_create(**kwargs):
+        assert kwargs["messages"][1]["content"] == content
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr("bot.bot._create_chat_completion", fake_create)
+    bot_instance = OpenAIBot()
+    reply = bot_instance.ask(content)
+    assert reply == "ok"


### PR DESCRIPTION
## Summary
- update default OpenAI model to `gpt-4o`
- allow `OpenAIBot.ask` to accept multimodal content
- support photo messages in the Telegram bot via base64 image transfer
- test new image support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686408c76dac8320b7107460071f1951