### PR TITLE
Enable conversation context

### DIFF
--- a/bot/settings.py
+++ b/bot/settings.py
@@ -4,6 +4,7 @@ TELEGRAM_TOKEN = "YOUR_TELEGRAM_TOKEN"
 OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
 MODEL = "gpt-4o"
 CONTEXT_SIZE = 4096
+CONTEXT_WINDOW_MESSAGES = 20
 
 # List of assistants interacting with each other.
 # Each assistant has a role and a system prompt.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -47,3 +47,30 @@ def test_openai_bot_image(monkeypatch):
     bot_instance = OpenAIBot()
     reply = bot_instance.ask(content)
     assert reply == "ok"
+
+
+def test_openai_bot_conversation(monkeypatch):
+    monkeypatch.setattr(
+        settings, "ASSISTANTS", [{"role": "assistant", "system_prompt": "A"}]
+    )
+
+    replies = [
+        {"choices": [{"message": {"content": "first"}}]},
+        {"choices": [{"message": {"content": "second"}}]},
+    ]
+
+    def fake_create(**kwargs):
+        return replies.pop(0)
+
+    monkeypatch.setattr("bot.bot._create_chat_completion", fake_create)
+    bot_instance = OpenAIBot()
+    conv = []
+    bot_instance.ask("hi", conv)
+    bot_instance.ask("again", conv)
+
+    assert conv == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "first"},
+        {"role": "user", "content": "again"},
+        {"role": "assistant", "content": "second"},
+    ]


### PR DESCRIPTION
## Summary
- store chat history and truncate according to settings
- allow resetting dialog context via `/clear`
- support conversation lists in `OpenAIBot.ask`
- add tests covering conversation behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641060d35083209cf5213e6ab4b057