### PR TITLE
Add Excel and CSV document support

### DIFF
--- a/bot/settings.py
+++ b/bot/settings.py
@@ -5,6 +5,7 @@ OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
 MODEL = "gpt-4o"
 CONTEXT_SIZE = 4096
 CONTEXT_WINDOW_MESSAGES = 20
+DOC_MAX_CHARS = 2000
 
 # List of assistants interacting with each other.
 # Each assistant has a role and a system prompt.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 openai
 python-telegram-bot
+pdfminer.six
+python-docx
+openpyxl
+xlrd


### PR DESCRIPTION
## Summary
- extend document parsing to handle XLSX, XLS, CSV
- add openpyxl and xlrd dependencies
- provide unit tests covering CSV, XLSX and DOCX parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641b80f7b08320bd6e6e062def08d4