### PR TITLE
Add DOC parsing via textract

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pdfminer.six
 python-docx
 openpyxl
 xlrd
+textract==1.6.3

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,6 +3,7 @@ import asyncio
 from io import BytesIO
 import openpyxl
 import docx
+import textract
 
 import bot.settings as settings
 from bot.bot import OpenAIBot, setup_openai, TelegramBot
@@ -241,6 +242,25 @@ def test_read_document_text_docx():
         doc = _dummy_document("doc.docx", bio.getvalue())
         text = await bot_instance._read_document_text(doc)
         assert "test" in text
+
+    asyncio.run(run())
+
+
+def test_read_document_text_doc(monkeypatch):
+    async def run():
+        bot_instance = TelegramBot()
+        doc = _dummy_document("sample.doc", b"dummy")
+
+        processed = {}
+
+        def fake_process(filename):
+            processed["file"] = filename
+            return b"doc text"
+
+        monkeypatch.setattr(textract, "process", fake_process)
+        text = await bot_instance._read_document_text(doc)
+        assert "doc text" in text
+        assert processed
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- handle older pdfminer by defining `extract_text`
- parse `.doc` attachments using textract
- add textract to requirements
- test DOC parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686423a6754c8320af945c90f360ea7d