### PR TITLE
Use mammoth for DOC files

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -22,8 +22,7 @@ except ImportError:  # pragma: no cover - older pdfminer versions
 import docx
 import openpyxl
 import xlrd
-import tempfile
-import textract
+import mammoth
 
 try:  # Allow running tests without installed packages
     import openai
@@ -169,10 +168,7 @@ class TelegramBot:
                         rows.append(",".join(str(c) for c in row))
                 text = "\n".join(rows)
             elif name.endswith(".doc"):
-                with tempfile.NamedTemporaryFile(suffix=".doc") as tmp:
-                    tmp.write(data)
-                    tmp.flush()
-                    text = textract.process(tmp.name).decode("utf-8", errors="ignore")
+                text = mammoth.convert_to_markdown(BytesIO(data)).value
             else:
                 text = data.decode("utf-8", errors="ignore")
         except Exception as exc:  # pragma: no cover - fallback if parsing fails

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ python-telegram-bot
 pdfminer.six
 python-docx
 openpyxl
-xlrd
-textract==1.6.3
+xlrd==1.2.0
+mammoth

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,7 +3,7 @@ import asyncio
 from io import BytesIO
 import openpyxl
 import docx
-import textract
+import mammoth
 
 import bot.settings as settings
 from bot.bot import OpenAIBot, setup_openai, TelegramBot
@@ -253,11 +253,13 @@ def test_read_document_text_doc(monkeypatch):
 
         processed = {}
 
-        def fake_process(filename):
-            processed["file"] = filename
-            return b"doc text"
+        def fake_convert(fileobj):
+            processed["called"] = True
+            assert fileobj.read() == b"dummy"
+            fileobj.seek(0)
+            return types.SimpleNamespace(value="doc text")
 
-        monkeypatch.setattr(textract, "process", fake_process)
+        monkeypatch.setattr(mammoth, "convert_to_markdown", fake_convert)
         text = await bot_instance._read_document_text(doc)
         assert "doc text" in text
         assert processed


### PR DESCRIPTION
## Summary
- replace `textract` with `mammoth` for `.doc` parsing
- pin `xlrd` to 1.2.0 and drop textract
- adjust tests for new DOC parser

## Testing
- `pip install -r requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864376c575083209a38d7578f310075