### PR TITLE
Add consilium mode with doctor and critic

### DIFF
--- a/bot/settings.py
+++ b/bot/settings.py
@@ -12,3 +12,24 @@ DOC_MAX_CHARS = 2000
 ASSISTANTS = [
     {"role": "assistant", "system_prompt": "You are a helpful assistant."},
 ]
+
+# Assistants used when the user starts a medical consilium. The first agent acts
+# as a doctor providing advice, and the second agent critiques the doctor's
+# conclusions.
+CONSILIUM_ASSISTANTS = [
+    {
+        "role": "doctor",
+        "system_prompt": (
+            "You are an experienced medical doctor. Provide detailed clinical "
+            "opinions and suggestions based on the user's questions."
+        ),
+    },
+    {
+        "role": "critic",
+        "system_prompt": (
+            "You critically evaluate the doctor's response. Point out "
+            "potential issues or missing considerations and suggest "
+            "improvements."
+        ),
+    },
+]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -285,3 +285,44 @@ def test_read_document_text_doc(monkeypatch):
 
     asyncio.run(run())
 
+
+def test_consilium_mode(monkeypatch):
+    async def run():
+        responses = []
+
+        class DummyMessage:
+            caption = None
+            text = "hi"
+            photo = None
+            document = None
+            audio = None
+            media_group_id = None
+
+            def __init__(self):
+                self.chat_id = 1
+
+            async def reply_text(self, text):
+                responses.append(text)
+
+        bot_instance = TelegramBot()
+
+        # default bot reply
+        monkeypatch.setattr(bot_instance.bot, "ask", lambda c, conv=None: "default")
+
+        update = types.SimpleNamespace(message=DummyMessage(), effective_chat=types.SimpleNamespace(id=1))
+        ctx = types.SimpleNamespace(application=types.SimpleNamespace(create_task=lambda c: None))
+
+        await bot_instance.start_consilium(update, ctx)
+        assert 1 in bot_instance.bots
+
+        monkeypatch.setattr(bot_instance.bots[1], "ask", lambda c, conv=None: "consilium")
+        await bot_instance.handle_message(update, ctx)
+        assert responses[-1] == "consilium"
+
+        await bot_instance.stop_consilium(update, ctx)
+        assert 1 not in bot_instance.bots
+        await bot_instance.handle_message(update, ctx)
+        assert responses[-1] == "default"
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- add `CONSILIUM_ASSISTANTS` setting defining doctor and critic agents
- extend `TelegramBot` with `/consilium` and `/stopconsilium` commands
- keep per-chat `OpenAIBot` instances for consilium mode
- update start message to mention new commands
- adjust message processing to use chat specific bots
- add tests for consilium mode

## Testing
- `pip install -r requirements.txt`
- `pip install pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686569d9f1fc8320b55bd1eedd944cf1