### PR TITLE
Fix long message handling

### DIFF
--- a/bot/settings.py
+++ b/bot/settings.py
@@ -6,6 +6,7 @@ MODEL = "gpt-4o"
 CONTEXT_SIZE = 4096
 CONTEXT_WINDOW_MESSAGES = 20
 DOC_MAX_CHARS = 2000
+TELEGRAM_MAX_CHARS = 4096
 
 # List of assistants interacting with each other.
 # Each assistant has a role and a system prompt.


### PR DESCRIPTION
## Summary
- introduce `TELEGRAM_MAX_CHARS` setting
- split long text replies when sending

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657fb5fc948320b7d7f7b7e2636f98