### PR TITLE
Fix .doc file handling

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -187,16 +187,20 @@ class TelegramBot:
                 )
                 images = tree.xpath("//img/@src")
             elif name.endswith(".doc"):
-                with tempfile.NamedTemporaryFile(delete=False, suffix=".doc") as tmp:
-                    tmp.write(data)
-                    tmp.flush()
+                fd, path = tempfile.mkstemp(suffix=".doc")
+                try:
+                    with os.fdopen(fd, "wb") as tmp:
+                        tmp.write(data)
                     try:
                         result = subprocess.run(
-                            ["antiword", tmp.name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+                            ["antiword", path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
                         )
                         text = result.stdout.decode("utf-8", errors="ignore")
-                    finally:
-                        os.unlink(tmp.name)
+                    except FileNotFoundError:
+                        logger.error("antiword not found - cannot extract .doc text")
+                        return "", []
+                finally:
+                    os.unlink(path)
             elif name.endswith(".xlsx"):
                 wb = openpyxl.load_workbook(BytesIO(data), read_only=True, data_only=True)
                 rows = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-docx
 openpyxl
 xlrd==1.2.0
 mammoth
+Pillow

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -287,6 +287,23 @@ def test_read_document_text_doc(monkeypatch):
     asyncio.run(run())
 
 
+def test_read_document_text_doc_no_antiword(monkeypatch):
+    async def run():
+        bot_instance = TelegramBot()
+        doc = _dummy_document("sample.doc", b"dummy")
+
+        def fake_run(*a, **k):
+            raise FileNotFoundError
+
+        import subprocess
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        text, images = await bot_instance._read_document_text(doc)
+        assert text == ""
+        assert images == []
+
+    asyncio.run(run())
+
+
 def test_consilium_mode(monkeypatch):
     async def run():
         responses = []


### PR DESCRIPTION
## Summary
- close temporary file before running antiword
- gracefully handle missing antiword
- install Pillow for tests
- add regression test for missing antiword

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658208f7388320a972b5f1964fe8c5