### PR TITLE
Remove antiword dependency

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -264,41 +264,13 @@ def test_read_document_text_docx():
     asyncio.run(run())
 
 
-def test_read_document_text_doc(monkeypatch):
+def test_read_document_text_doc():
     async def run():
         bot_instance = TelegramBot()
-        doc = _dummy_document("sample.doc", b"dummy")
-
-        processed = {}
-
-        def fake_run(cmd, stdout=None, stderr=None, check=None):
-            processed["cmd"] = cmd
-            assert "antiword" in cmd[0]
-            # simulate successful conversion
-            return types.SimpleNamespace(stdout=b"doc text")
-
-        import subprocess
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        data = "doc text".encode("utf-16le")
+        doc = _dummy_document("sample.doc", data)
         text, images = await bot_instance._read_document_text(doc)
         assert "doc text" in text
-        assert images == []
-        assert processed
-
-    asyncio.run(run())
-
-
-def test_read_document_text_doc_no_antiword(monkeypatch):
-    async def run():
-        bot_instance = TelegramBot()
-        doc = _dummy_document("sample.doc", b"dummy")
-
-        def fake_run(*a, **k):
-            raise FileNotFoundError
-
-        import subprocess
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        text, images = await bot_instance._read_document_text(doc)
-        assert text == ""
         assert images == []
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- parse legacy DOC files using a simple Python decoder instead of calling antiword
- update tests for new DOC parsing behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663ae79c708320a1d52711bc729a26