### PR TITLE
Improve consilium flow

### DIFF
--- a/bot/settings.py
+++ b/bot/settings.py
@@ -33,4 +33,13 @@ CONSILIUM_ASSISTANTS = [
             "improvements."
         ),
     },
+    {
+        "role": "doctor_final",
+        "system_prompt": (
+            "You are the same doctor addressing the critic's comments. "
+            "Provide a concise response to the critique and formulate "
+            "final thoughts and recommendations based on all prior "
+            "messages and any provided documents."
+        ),
+    },
 ]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -36,7 +36,7 @@ def test_openai_bot_sequential(monkeypatch):
     monkeypatch.setattr("bot.bot._create_chat_completion", fake_create)
     bot_instance = OpenAIBot()
     reply = bot_instance.ask("hello")
-    assert reply == "assistant1: first\n\nassistant2: second"
+    assert reply == [("assistant1", "first"), ("assistant2", "second")]
 
 
 def test_openai_bot_image(monkeypatch):


### PR DESCRIPTION
## Summary
- allow `OpenAIBot.ask()` to return a list of role replies
- output multi-message replies in `TelegramBot`
- add a final doctor assistant step to consilium mode
- update tests for new list reply behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663d15b0d08320bff3dd4d9eee4120