### PR TITLE
Fix OpenAI API key setup

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -184,6 +184,9 @@ class TelegramBot:
             self.application.add_handler(CommandHandler("model", self.set_model))
             self.application.add_handler(MessageHandler(filters.ALL, self.handle_message))
 
+        # Configure OpenAI before making any API requests
+        setup_openai()
+
         self.available_models = self._fetch_models()
         self.bot = OpenAIBot(model=settings.MODEL)
         # Per-chat specialized bots, used for the consilium mode


### PR DESCRIPTION
## Summary
- configure OpenAI before fetching model list so API key is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667418a3908320baf7cd4316e4d155