### PR TITLE
Fix chat model detection

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -71,7 +71,7 @@ def _is_chat_model(model: str | None) -> bool:
     if not model:
         return True
     name = str(model).lower().strip()
-    if name.startswith("gpt-") and "-instruct" not in name:
+    if "gpt-" in name and "-instruct" not in name:
         return True
     if name.startswith("claude"):
         return True


### PR DESCRIPTION
## Summary
- detect chat models that include `gpt-` anywhere in the name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d48ba5d883208f4e14390c9a5b09