### PR TITLE
Fix chat model detection for o4 prefix

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -75,6 +75,8 @@ def _is_chat_model(model: str | None) -> bool:
         return True
     if name.startswith("claude"):
         return True
+    if name.startswith("o4"):
+        return True
     return False
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -9,6 +9,7 @@ import pytest
 
 import bot.settings as settings
 from bot.bot import OpenAIBot, setup_openai, TelegramBot
+from bot.bot import _is_chat_model
 
 
 @pytest.fixture(autouse=True)
@@ -32,6 +33,11 @@ def test_setup_openai(monkeypatch):
     monkeypatch.setattr("bot.bot.openai", fake_openai)
     setup_openai()
     assert fake_openai.api_key == "key"
+
+
+def test_is_chat_model_o4():
+    assert _is_chat_model("o4-mini")
+    assert not _is_chat_model("gpt-3.5-instruct")
 
 
 def test_openai_bot_sequential(monkeypatch):


### PR DESCRIPTION
## Summary
- recognize `o4` model prefix as chat-based
- test for `o4-mini` in `_is_chat_model`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d94e3a988320930e55eb15f8730c